### PR TITLE
Resolved carousel image heights

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             </div>
         </div>
         <div class="jumbotron jumbotron_flowers vertical_center">
-            <div class="container-fluid">
+            <div class="c-fluid conflict" id="blah">
                     <h1>GET CREATING.</h1>
                     <p>Stop overthinking projects and begin putting them out into the world.</p>
             </div>

--- a/index.html
+++ b/index.html
@@ -5,15 +5,23 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Jumpstart</title>
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">
+    <link rel="icon" href="./favicon.ico" type="image/x-icon">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" media="screen" href="resources/css/reset.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
-    <link rel="stylesheet" type="text/css" media="screen" href="resources/css/style.css"/>
+
     <link href="https://fonts.googleapis.com/css?family=Monoton|Open+Sans:400,600,700" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="slick/slick.css"/>
+
+    <link rel="stylesheet" type="text/css" media="screen" href="./resources/css/reset.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="./slick/slick.css"/>
+    <link rel="stylesheet" type="text/css" media="screen" href="./resources/css/style.css"/>
+
+    <script
+        src="https://code.jquery.com/jquery-3.3.1.min.js"
+        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        crossorigin="anonymous"></script>
+    <script src="./resources/js/main.js"></script>
+    <script type="text/javascript" src="./slick/slick.min.js"></script>
 </head>
 <body>
     <!-- Navigation Bar -->
@@ -31,25 +39,25 @@
     <!-- Jumbotron -->
     <div class="carousel">
         <div class="jumbotron jumbotron_bike vertical_center">
-            <div class="container_fluid">
+            <div class="container-fluid">
                 <h1>Get Going</h1>
                 <p>Jumpstart your startup with some crowdsourced seed money, or support one of our 300,000,000+ creators and get rewards.</p>
             </div>
         </div>
         <div class="jumbotron jumbotron_beer">
-            <div class="container_fluid">
+            <div class="container-fluid">
                     <h1>GET THINKING.</h1>
                     <p>Meet like-minded individuals who will help fuel your creative juices.</p>
             </div>
         </div>
         <div class="jumbotron jumbotron_flowers vertical_center">
-            <div class="container_fluid">
+            <div class="container-fluid">
                     <h1>GET CREATING.</h1>
                     <p>Stop overthinking projects and begin putting them out into the world.</p>
             </div>
         </div>
         <div class="jumbotron jumbotron_duffel vertical_center">
-            <div class="container_fluid">
+            <div class="container-fluid">
                     <h1>GET STARTED.</h1>
                     <p>What are you waiting for? Today's the day for your next big idea.</p>
             </div>
@@ -132,17 +140,5 @@
         <button type="button" id="jump_in" class="btn btn-default btn-primary btn-lg">Learn more</button>
         
     </div>
-
-<script
-src="https://code.jquery.com/jquery-3.3.1.min.js"
-integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-crossorigin="anonymous"></script>
-<script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
-<script src="resources/js/main.js"></script>
-<script type="text/javascript" src="//code.jquery.com/jquery-1.11.0.min.js"></script>
-<script type="text/javascript" src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
-<script type="text/javascript" src="slick/slick.min.js"></script>
-                
-
 </body>
 </html>

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -56,6 +56,8 @@ h3 {
 .jumbotron {
     color: white;
     text-align: center;
+    height: 44rem;
+    padding-top: 15rem;
 }
 
 .jumbotron h1 {
@@ -65,9 +67,11 @@ h3 {
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
+/*
 .container_fluid {
     max-width: 53.1rem;
 }
+*/
 
 .relative-container {
     position: relative;


### PR DESCRIPTION
I think the main issue was you had included 2 different jquery versions and 2 different slick versions on the same page, so things were conflicting and getting messed up.  After I dealt with that it was just a matter of adding a `height` and `padding-top` to your `.jumbotron` class and fixing a bootstrap class typo (e.g. `container-fluid` instead of `container_fluid`).